### PR TITLE
fix(npm-scripts): remove postinstall script and call to bower verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
     "tag": "git tag -a $npm_package_version -m \"Version $npm_package_version\"",
     "push:release": "git push origin master && git push origin $npm_package_version",
     "publish:npm": "npm publish && npm run verify",
-    "verify": "npm run verify:npm && npm run verify:bower",
+    "verify": "npm run verify:npm",
     "verify:npm": "npm view $npm_package_name version",
-    "verify:bower": "bower info $npm_package_name version",
-    "postinstall": "bower install"
+    "verify:bower": "bower info $npm_package_name version"
   },
   "authors": [
     "Greg Deane <greg.james.deane@zalando.de>"


### PR DESCRIPTION
@dami-gg @cjhowald I left `verify:bower` in place for now. I only removed the `npm run verify:bower` command. This is so we can use the script directly as well as for possible future use.