### PR TITLE
feat(environments): update user and token service URLs

### DIFF
--- a/src/environments/environments.constant.js
+++ b/src/environments/environments.constant.js
@@ -5,60 +5,60 @@ module.exports.ENVIRONMENTS = {
     URL: 'https://www.solutions.zalando.com',
     DOMAIN: 'solutions.zalando.com',
     PORT: '',
-    USER_SERVICE: 'https://user-management.norris.zalan.do',
-    TOKEN_SERVICE: 'https://token-management.norris.zalan.do',
+    USER_SERVICE_OLD: 'https://user-management.norris.zalan.do',
+    TOKEN_SERVICE_OLD: 'https://token-management.norris.zalan.do',
     MERCHANT_SERVICE: 'https://merchant-management.norris.zalan.do',
     GOODDATA_SERVICE: 'https://gooddata.norris.zalan.do',
     MODULE_SERVICE: 'https://module-service.norris.zalan.do',
-    USER_SERVICE_NEW: 'https://user-service.norris.zalan.do'
+    USER_SERVICE: 'https://user-service.norris.zalan.do'
   },
   STAGE: {
     NAME: 'STAGE',
     URL: 'https://sc-stage.norris.zalan.do',
     DOMAIN: '.zalan.do',
     PORT: '',
-    USER_SERVICE: 'https://um-stage.norris.zalan.do',
-    TOKEN_SERVICE: 'https://tm-stage.norris.zalan.do',
+    USER_SERVICE_OLD: 'https://um-stage.norris.zalan.do',
+    TOKEN_SERVICE_OLD: 'https://tm-stage.norris.zalan.do',
     MERCHANT_SERVICE: 'https://merchant-stage.norris.zalan.do',
     GOODDATA_SERVICE: 'https://gooddata-stage.norris.zalan.do',
     MODULE_SERVICE: 'https://ms-stage.norris.zalan.do',
-    USER_SERVICE_NEW: 'https://us2-stage.norris.zalan.do'
+    USER_SERVICE: 'https://us-stage.norris.zalan.do'
   },
   INTEGRATION: {
     NAME: 'INTEGRATION',
     URL: 'https://sc-integration.norris.zalan.do',
     DOMAIN: '.zalan.do',
     PORT: '',
-    USER_SERVICE: 'https://um-integration.norris.zalan.do',
-    TOKEN_SERVICE: 'https://tm-integration.norris.zalan.do',
+    USER_SERVICE_OLD: 'https://um-integration.norris.zalan.do',
+    TOKEN_SERVICE_OLD: 'https://tm-integration.norris.zalan.do',
     MERCHANT_SERVICE: 'https://merchant-integration.norris.zalan.do',
     GOODDATA_SERVICE: 'https://gooddata-integration.norris.zalan.do',
     MODULE_SERVICE: 'https://ms-integration.norris.zalan.do',
-    USER_SERVICE_NEW: 'https://us2-integration.norris.zalan.do'
+    USER_SERVICE: 'https://us-integration.norris.zalan.do'
   },
   DEVELOPMENT: {
     NAME: 'DEVELOPMENT',
     URL: 'https://sc-development.norris.zalan.do',
     DOMAIN: '.zalan.do',
     PORT: '',
-    USER_SERVICE: 'https://um-development.norris.zalan.do',
-    TOKEN_SERVICE: 'https://tm-development.norris.zalan.do',
+    USER_SERVICE_OLD: 'https://um-development.norris.zalan.do',
+    TOKEN_SERVICE_OLD: 'https://tm-development.norris.zalan.do',
     MERCHANT_SERVICE: 'https://merchant-development.norris.zalan.do',
     GOODDATA_SERVICE: 'https://gooddata-development.norris.zalan.do',
     MODULE_SERVICE: 'https://ms-development.norris.zalan.do',
-    USER_SERVICE_NEW: 'https://us2-development.norris.zalan.do'
+    USER_SERVICE: 'https://us-development.norris.zalan.do'
   },
   LOCAL: {
     NAME: 'LOCAL',
     URL: 'http://localhost',
     DOMAIN: 'localhost',
     PORT: 3333,
-    USER_SERVICE: 'https://um-development.norris.zalan.do',
-    TOKEN_SERVICE: 'https://tm-development.norris.zalan.do',
+    USER_SERVICE_OLD: 'https://um-development.norris.zalan.do',
+    TOKEN_SERVICE_OLD: 'https://tm-development.norris.zalan.do',
     MERCHANT_SERVICE: 'https://merchant-development.norris.zalan.do',
     GOODDATA_SERVICE: 'https://gooddata-development.norris.zalan.do',
     MODULE_SERVICE: 'https://ms-development.norris.zalan.do',
-    USER_SERVICE_NEW: 'https://us2-development.norris.zalan.do'
+    USER_SERVICE: 'https://us-development.norris.zalan.do'
   },
   TESTING: {
     NAME: 'TESTING',

--- a/src/environments/environments.constant.js
+++ b/src/environments/environments.constant.js
@@ -65,11 +65,11 @@ module.exports.ENVIRONMENTS = {
     URL: '',
     DOMAIN: '',
     PORT: '',
-    USER_SERVICE: '',
-    TOKEN_SERVICE: '',
+    USER_SERVICE_OLD: '',
+    TOKEN_SERVICE_OLD: '',
     MERCHANT_SERVICE: '',
     GOODDATA_SERVICE: '',
     MODULE_SERVICE: '',
-    USER_SERVICE_NEW: ''
+    USER_SERVICE: ''
   }
 };

--- a/test/environments.constant.spec.js
+++ b/test/environments.constant.spec.js
@@ -4,8 +4,8 @@ describe('constants', function () {
 
   var environmentNames = ['PRODUCTION', 'STAGE', 'INTEGRATION', 'DEVELOPMENT', 'LOCAL', 'TESTING'],
       environmentProps = [
-        'NAME', 'URL', 'DOMAIN', 'PORT', 'USER_SERVICE', 'TOKEN_SERVICE',
-        'MERCHANT_SERVICE', 'GOODDATA_SERVICE', 'MODULE_SERVICE', 'USER_SERVICE_NEW'
+        'NAME', 'URL', 'DOMAIN', 'PORT', 'USER_SERVICE', 'TOKEN_SERVICE_OLD',
+        'MERCHANT_SERVICE', 'GOODDATA_SERVICE', 'MODULE_SERVICE', 'USER_SERVICE_OLD'
       ],
       config,
       defaultEnvironment;


### PR DESCRIPTION
Fixes #48 

BREAKING CHANGE: USER_SERVICE and TOKEN_SERVICE keys have changed to
  USER_SERVICE_OLD and TOKEN_SERVICE_OLD, USER_SERVICE now points
  to the new user/token service, TOKEN_SERVICE has been removed

  To use the new user/token service, use USER_SERVICE:

  ```js
  var env = ScEnvironmentsProvider.getCurrentEnvironment();
  var tokenEndpoint = env.USER_SERVICE + '/tokens';
  var userEndpoint = env.USER_SERVICE + '/users';
  ```

  If you need to continue using the old services, change your code from this:

  ```js
  var env = ScEnvironmentsProvider.getCurrentEnvironment();
  var oldTokenEndpoint = env.TOKEN_SERVICE + '/tokens';
  var oldUserEndpoint = env.USER_SERVICE + '/users';
  ```

  To this:

  ```js
  var env = ScEnvironmentsProvider.getCurrentEnvironment();
  var oldTokenEndpoint = env.TOKEN_SERVICE_OLD + '/tokens';
  var oldUserEndpoint = env.USER_SERVICE_OLD + '/users';
  ```